### PR TITLE
Fix Windows .exe build: Use Ruby 3.2 for OCRA compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby-version: ['3.3']
+        include:
+          # Use Ruby 3.2 for Windows builds due to OCRA compatibility
+          - os: windows-latest
+            ruby-version: '3.2'
 
     steps:
       - name: Checkout code

--- a/build/windows/build.rb
+++ b/build/windows/build.rb
@@ -67,6 +67,25 @@ system(cmd)
 
 if File.exist?(OUTPUT_EXE)
   size_mb = File.size(OUTPUT_EXE) / (1024.0 * 1024.0)
+
+  # OCRA executables with Ruby runtime should be at least 10 MB
+  # If smaller, the build likely failed
+  if size_mb < 10.0
+    puts ""
+    puts "======================================================"
+    puts "ERROR: Build failed - executable too small"
+    puts "======================================================"
+    puts "  Executable: #{OUTPUT_EXE}"
+    puts "  Size: #{size_mb.round(2)} MB (expected > 10 MB)"
+    puts ""
+    puts "This usually indicates OCRA failed to bundle Ruby runtime."
+    puts "Check that:"
+    puts "  - Ruby version is compatible with OCRA (try Ruby 3.2)"
+    puts "  - OCRA gem installed correctly: gem install ocra"
+    puts "======================================================"
+    exit 1
+  end
+
   puts ""
   puts "======================================================"
   puts "SUCCESS!"
@@ -84,7 +103,7 @@ if File.exist?(OUTPUT_EXE)
 else
   puts ""
   puts "======================================================"
-  puts "ERROR: Build failed"
+  puts "ERROR: Build failed - executable not created"
   puts "======================================================"
   exit 1
 end


### PR DESCRIPTION
## Fix Windows Executable Build Issue

This PR fixes the \"Bad signature in executable\" error in the Windows .exe by switching to Ruby 3.2 for OCRA builds.

### 🐛 Problem

The v0.6.4 release produced a corrupted Windows .exe (only 50KB instead of 15-30MB):
- **Error**: `FATAL ERROR: Bad signature in executable`
- **Root cause**: OCRA 1.3.11 is incompatible with Ruby 3.3
- **Missing file**: `fiber.so` not found in Ruby 3.3 structure

### ✅ Solution

**1. Use Ruby 3.2 for Windows builds** (`.github/workflows/release.yml`)
- Windows: Ruby 3.2 (OCRA-compatible)
- Ubuntu/macOS: Ruby 3.3 (unchanged)
- Gem still supports Ruby 2.7-3.3

**2. Add build validation** (`build/windows/build.rb`)
- Check exe file size must be > 10 MB
- Fail fast with clear error message
- Prevent uploading broken executables

### 📦 Impact

- Windows .exe will work properly for non-technical users (artists)
- Gem distribution unaffected (uses Ruby 3.3)
- All tests still run on Ruby 2.7-3.3

### 🚀 Next Steps

After merge:
1. Delete broken v0.6.4 release and tag
2. Re-push v0.6.4 tag to trigger new build
3. Verify Windows .exe downloads and runs correctly

---

Fixes the Windows .exe issue discovered in #24