### PR TITLE
Remove Windows .exe: Focus on gem distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         ruby-version: ['3.3']
-        include:
-          # Use Ruby 3.2 for Windows builds due to OCRA compatibility
-          - os: windows-latest
-            ruby-version: '3.2'
 
     steps:
       - name: Checkout code
@@ -40,37 +36,11 @@ jobs:
       - name: Build gem
         run: gem build ruby_spriter.gemspec
 
-      - name: Get version from tag
-        id: get_version
-        shell: bash
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Install OCRA (Windows only)
-        if: matrix.os == 'windows-latest'
-        run: gem install ocra
-
-      - name: Build Windows executable
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          ruby build/windows/build.rb
-          mv ruby_spriter.exe ruby_spriter-${{ steps.get_version.outputs.version }}-windows.exe
-
       - name: Upload gem artifact
         uses: actions/upload-artifact@v4
         with:
           name: gem-${{ matrix.os }}
           path: ruby_spriter-*.gem
-
-      - name: Upload Windows exe artifact
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-exe
-          path: ruby_spriter-*-windows.exe
 
   publish:
     name: Publish to RubyGems and Create GitHub Release
@@ -90,11 +60,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gem-ubuntu-latest
-
-      - name: Download Windows exe artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-exe
 
       - name: Get version and changelog
         id: get_info
@@ -121,9 +86,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: release_notes.md
-          files: |
-            ruby_spriter-*.gem
-            ruby_spriter-*-windows.exe
+          files: ruby_spriter-*.gem
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,20 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - **GitHub Actions CI/CD Pipeline**: Automated testing across Ruby 2.7-3.3 on Ubuntu, macOS, and Windows
 - **Automated RubyGems Publishing**: Auto-publish gem to RubyGems.org on version tag push
-- **Windows Standalone Executable**: OCRA-based .exe build for non-Ruby users (automated in CI)
-- **Release Automation Workflow**: Multi-platform builds with artifact uploads to GitHub Releases
+- **Release Automation Workflow**: Multi-platform gem builds with artifact uploads to GitHub Releases
 - **Code Coverage Reporting**: SimpleCov integration in CI with PR summaries
 
 #### Changed
-- **Installation Options**: Three distinct installation methods (RubyGems, Windows .exe, from source)
-- **README Structure**: Completely restructured installation section with platform-specific guidance
+- **Installation Options**: Two installation methods (RubyGems for all platforms, from source)
+- **README Structure**: Simplified installation section focusing on gem distribution
 - **Gemspec Author Info**: Updated from placeholders to actual author details
-- **Build Infrastructure**: Added `build/windows/build.rb` script for OCRA executable generation
 
 #### Distribution
-- **RubyGems**: Published gem with all runtime files
-- **Windows .exe**: Standalone executable with bundled Ruby runtime (external dependencies still required)
+- **RubyGems**: Published gem with all runtime files (works on Windows, macOS, Linux)
 - **Source Install**: Git clone with local gem build option
+
+#### Deferred
+- **Windows Standalone Executable**: Deferred due to OCRA incompatibility with Ruby 3.x
+  - OCRA 1.3.11 (last version, 2019) fails with Ruby 3.2+ due to internal fiber changes
+  - Windows users can use `gem install ruby_spriter` after installing Ruby
+  - Will revisit when better Windows packaging tools become available
 
 Closes #18
 

--- a/README.md
+++ b/README.md
@@ -116,32 +116,11 @@ gem install ruby_spriter
 ```
 
 **Requirements**: Ruby 2.7 or higher
-**Best for**: Ruby developers, automated workflows
+**Best for**: All platforms (Windows, macOS, Linux), automated workflows
 
 ---
 
-#### 🪟 **Option B: Windows Standalone Executable**
-
-Download the standalone .exe - **no Ruby installation required!**
-
-1. Go to [Releases](https://github.com/scooter-indie/ruby-spriter/releases)
-2. Download `ruby_spriter-X.Y.Z-windows.exe`
-3. Add to your PATH or run directly
-
-```powershell
-# Run directly
-.\ruby_spriter.exe --version
-
-# Or add to PATH and use anywhere
-ruby_spriter --version
-```
-
-**Best for**: Windows users without Ruby, non-technical users
-**Note**: Still requires FFmpeg, ImageMagick, and GIMP (install via Chocolatey above)
-
----
-
-#### 🛠️ **Option C: From Source (Development)**
+#### 🛠️ **Option B: From Source (Development)**
 
 Clone and build from source:
 


### PR DESCRIPTION
## Remove Windows Standalone Executable

After extensive investigation, OCRA (One-Click Ruby Application) is incompatible with Ruby 3.x and cannot produce working Windows executables.

### 🐛 Problem

**OCRA 1.3.11 (last update: 2019) fails with Ruby 3.x:**
- Ruby 3.3: `fiber.so not found` error
- Ruby 3.2: Same `fiber.so not found` error  
- Root cause: Internal Ruby fiber API changes in 3.x series
- Result: Corrupted 50KB executables with "Bad signature" error

### ✅ Solution: Focus on Gem Distribution

Removed Windows .exe build entirely and simplified to gem-only distribution:

**Changes in this PR:**
- Remove Windows from release workflow matrix
- Remove OCRA installation and build steps
- Remove Windows .exe artifact handling
- Update README: Remove Windows .exe option (keep RubyGems + source)
- Update CHANGELOG: Document deferral with technical explanation

### 📦 Distribution Strategy

**Works on all platforms including Windows:**
```bash
gem install ruby_spriter
```

**For non-Ruby users on Windows:**
1. Install Ruby: https://rubyinstaller.org/ (one-time setup)
2. Install gem: `gem install ruby_spriter`
3. Works identically to Linux/macOS

### 🔮 Future

Will revisit Windows standalone executable when:
- OCRA is updated for Ruby 3.x (unlikely - unmaintained since 2019)
- Better Windows packaging tools emerge
- Community develops Ruby 3.x-compatible alternative

### 🎯 Impact

- ✅ Gem distribution works perfectly on all platforms
- ✅ Simpler CI/CD without OCRA complexity
- ✅ No broken/corrupted executables
- ✅ Clear documentation of limitations

---

Resolves the Windows .exe build failures from v0.6.4 release attempts.