### PR TITLE
Bump version to 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.4] - 2025-10-23
+## [0.6.5] - 2025-10-23
+
+### 📦 Distribution & Packaging Release
+
+**Note**: Version 0.6.5 is functionally identical to 0.6.4, which was yanked from RubyGems due to RubyGems policy preventing re-publication of yanked versions.
+
+#### Added
+- **GitHub Actions CI/CD Pipeline**: Automated testing across Ruby 2.7-3.3 on Ubuntu, macOS, and Windows
+- **Automated RubyGems Publishing**: Auto-publish gem to RubyGems.org on version tag push
+- **Release Automation Workflow**: Multi-platform gem builds with artifact uploads to GitHub Releases
+- **Code Coverage Reporting**: SimpleCov integration in CI with PR summaries
+
+#### Changed
+- **Installation Options**: Two installation methods (RubyGems for all platforms, from source)
+- **README Structure**: Simplified installation section focusing on gem distribution
+- **Gemspec Author Info**: Updated from placeholders to actual author details
+
+#### Distribution
+- **RubyGems**: Published gem with all runtime files (works on Windows, macOS, Linux)
+- **Source Install**: Git clone with local gem build option
+
+#### Deferred
+- **Windows Standalone Executable**: Deferred due to OCRA incompatibility with Ruby 3.x
+  - OCRA 1.3.11 (last version, 2019) fails with Ruby 3.2+ due to internal fiber changes
+  - Windows users can use `gem install ruby_spriter` after installing Ruby
+  - Will revisit when better Windows packaging tools become available
+
+Closes #18
+
+---
+
+## [0.6.4] - 2025-10-23 [YANKED]
+
+Version yanked from RubyGems. Use 0.6.5 instead.
 
 ### 📦 Distribution & Packaging Release
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ruby Spriter v0.6.4
+# Ruby Spriter v0.6.5
 
 [![Ruby](https://img.shields.io/badge/Ruby-2.7+-red.svg)](https://www.ruby-lang.org/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -134,7 +134,7 @@ bundle install
 
 # Build and install gem locally
 gem build ruby_spriter.gemspec
-gem install ruby_spriter-0.6.4.gem
+gem install ruby_spriter-0.6.5.gem
 ```
 
 **Best for**: Contributors, developers wanting latest code

--- a/lib/ruby_spriter/version.rb
+++ b/lib/ruby_spriter/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RubySpriter
-  VERSION = '0.6.4'
+  VERSION = '0.6.5'
   VERSION_DATE = '2025-10-23'
   METADATA_VERSION = '0.6'
 end


### PR DESCRIPTION
## Bump Version to 0.6.5

Version 0.6.4 cannot be re-published to RubyGems after being yanked due to RubyGems policy.

### 🔄 What Changed

**Version 0.6.5 is functionally identical to yanked 0.6.4** - same code, same features, different version number.

**Changes in this PR:**
- `lib/ruby_spriter/version.rb`: VERSION = '0.6.5'
- `CHANGELOG.md`: Added 0.6.5 section with note about yanked 0.6.4
- `CHANGELOG.md`: Marked 0.6.4 as [YANKED]
- `README.md`: Updated title and gem install command to 0.6.5

### 📋 Why the Version Bump

**RubyGems Policy**: Once a version is yanked, that version number is permanently retired and cannot be re-published. This is by design to prevent confusion and security issues.

**What happened:**
1. Version 0.6.4 was published during first release attempt
2. Windows .exe build failed, requiring documentation updates
3. Tried to yank and re-publish 0.6.4
4. RubyGems rejected: "A yanked version already exists (ruby_spriter-0.6.4)"

**Solution**: Bump to 0.6.5 with identical functionality.

### 🎯 After Merge

1. Tag v0.6.5
2. Push tag to trigger release workflow
3. Gem will publish successfully to RubyGems
4. GitHub Release created with gem artifact

---

This resolves the yanked version issue and allows clean release to RubyGems.